### PR TITLE
Show adding a new event to native and sending data to RN from native

### DIFF
--- a/ios/BrownFieldExample/HTReactNativeHostController.m
+++ b/ios/BrownFieldExample/HTReactNativeHostController.m
@@ -18,7 +18,7 @@
 static NSString * const kBundleURL =  @"http://localhost:8081/index.bundle?platform=ios";
 static NSString * const kPredicateFormat = @"name == %@";
 
-static BOOL kDevloperMode = false;
+static BOOL kDevloperMode = true;
 
 @interface MSREventBridgeBridgeManager : NSObject
 

--- a/ios/BrownFieldExample/ReactNativeConstants.swift
+++ b/ios/BrownFieldExample/ReactNativeConstants.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct RNEvents {
     public static let DismissScreen = "DismissScreen"
     public static let PurchaseItem = "PurchaseItem"
+    public static let ExampleEvent = "ExampleEvent"
     // Test event which causes react native
     public static let EmitEvent = "EmitEvent"
         
@@ -37,4 +38,5 @@ public struct RNProperties {
 public struct RNScreens {
     public static let Query = "Query"
     public static let UpsellScreenOne = "UpsellScreenOne"
+    public static let UpsellScreenSales = "UpsellScreenSales"
 }

--- a/ios/BrownFieldExample/ReactNativeViewController.swift
+++ b/ios/BrownFieldExample/ReactNativeViewController.swift
@@ -33,7 +33,18 @@ class ReactNativeViewController: HTReactNativeHostController {
             alert.addAction(UIAlertAction(title: "Okay", style: .default, handler: nil))
             self?.present(alert, animated: true, completion: nil)
         }));
-
+        
+        self.add(HTReactNativeEvent(name: RNEvents.ExampleEvent, handler: { [weak self] info in
+            guard let sku = info?[RNProperties.sku] as? String else { return }
+            /// Integrate with native purchase system in order to use SKU to make purchase with apple pay etc
+            let alertMessage = "Using ID: " + sku
+            let alert = UIAlertController(title: "Exampleevent hit!!!",
+                                          message: alertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "Okay", style: .default, handler: nil))
+            self?.present(alert, animated: true, completion: nil)
+            self?.sendReactNativeEvent(withName:RNEvents.EmitEvent, info: ["foo" : "bar"])
+        }));
+        
         self.add(HTReactNativeEvent(name: RNEvents.ListScreens, handler: { info in
             guard let screens = info?[RNProperties.screens] as? [[String: Any]] else { return }
             ReactNativeScreenManager.sharedInstance.reset()

--- a/src/const.js
+++ b/src/const.js
@@ -13,6 +13,7 @@ export const AppEvents = {
   DismissScreen: 'DismissScreen',
   PurchaseItem: 'PurchaseItem',
   ListScreens: 'ListScreens',
+  ExampleEvent: 'ExampleEvent',
   EmitEvent: 'EmitEvent',
   PurchaseSubscription: 'PurchaseSubscription',
 }
@@ -54,8 +55,8 @@ export const ScreenList = () => {
   return {
     'screens' :
     [
-      screenOne,
-      screenTwo,
+      // screenOne,
+      // screenTwo,
       screenThree,
     ]
   }

--- a/src/screens/UpsellScreenSales/index.js
+++ b/src/screens/UpsellScreenSales/index.js
@@ -22,7 +22,7 @@ class UpsellScreenSales extends Component {
     }
 
     purchase = (sku) => {
-        EventBridge.emitEvent(this, AppEvents.PurchaseItem, {sku});
+        EventBridge.emitEvent(this, AppEvents.ExampleEvent, {sku});
     }    
     
     render() {


### PR DESCRIPTION
This diff shows you how to:

- Add a new event to native/js.
- Send data from native into RN after the screen has been displayed. This happens when RN gets the example event.